### PR TITLE
Add missing SYSTEM_VERSION_GREATER_THAN_OR_EQUAL_TO macro

### DIFF
--- a/CRNavigationController/CRNavigationBar.m
+++ b/CRNavigationController/CRNavigationBar.m
@@ -17,6 +17,8 @@
 static CGFloat const kDefaultColorLayerOpacity = 0.5f;
 static CGFloat const kSpaceToCoverStatusBars = 20.0f;
 
+#define SYSTEM_VERSION_GREATER_THAN_OR_EQUAL_TO(v)  ([[[UIDevice currentDevice] systemVersion] compare:v options:NSNumericSearch] != NSOrderedAscending)
+
 - (void)setBarTintColor:(UIColor *)barTintColor {
 
     [super setBarTintColor:barTintColor];


### PR DESCRIPTION
In the sample code you have the definition in CRNavigationControllerExample-Prefix.pch.
